### PR TITLE
Modify replacement for multi selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,15 @@
       var ref;
       ref = null;
       return css.walkRules(function(rule) {
+        var i, len, ref1, result, selector;
         if (/^&/.test(rule.selector)) {
-          return rule.selector = rule.selector.replace(/&/, ref);
+          result = [];
+          ref1 = ref.split(/,/);
+          for (i = 0, len = ref1.length; i < len; i++) {
+            selector = ref1[i];
+            result.push(rule.selector.replace(/&/, selector));
+          }
+          return rule.selector = result.join(",");
         } else {
           return ref = rule.selector;
         }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,7 +11,10 @@ namespace = postcss.plugin 'postcss-namespace', (opts) ->
 
     css.walkRules (rule) ->
       if /^&/.test rule.selector
-        rule.selector = rule.selector.replace /&/, ref
+        result = []
+        for selector in ref.split /,/
+          result.push rule.selector.replace /&/, selector
+        rule.selector = result.join ","
       else
         ref = rule.selector
 

--- a/test/cases/multi-selector/answer.css
+++ b/test/cases/multi-selector/answer.css
@@ -1,0 +1,24 @@
+input, select, textarea {
+  border-color: #fff;
+}
+input:focus, select:focus, textarea:focus {
+  border-color: #f00;
+}
+
+input,
+select,
+textarea {
+  border-color: #fff;
+}
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: #f00;
+}
+
+input, select, textarea {
+  border-color: #fff;
+}
+input:focus, select:focus, textarea:focus {
+  border-color: #f00;
+}

--- a/test/cases/multi-selector/style.css
+++ b/test/cases/multi-selector/style.css
@@ -1,0 +1,22 @@
+input, select, textarea {
+  border-color: #fff;
+}
+&:focus {
+  border-color: #f00;
+}
+
+input,
+select,
+textarea {
+  border-color: #fff;
+}
+&:focus {
+  border-color: #f00;
+}
+
+input, select, textarea {
+  border-color: #fff;
+}
+&:focus {
+  border-color: #f00;
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -20,3 +20,9 @@ describe 'postcss-preref', ->
 
     result = postcss([preref]).process(style)
     expect(result.css).to.equal(answer)
+
+  it 'expect replace multi selector', ->
+    {style, answer} = set 'multi-selector'
+
+    result = postcss([preref]).process(style)
+    expect(result.css).to.equal(answer)


### PR DESCRIPTION
> Allow referencing parent selector for a list of elements #2
### Input

``` css
input, select, textarea {
  border-color: #fff;
}
&:focus {
  border-color: #f00;
}

input,
select,
textarea {
  border-color: #fff;
}
&:focus {
  border-color: #f00;
}

input, select, textarea {
  border-color: #fff;
}
&:focus {
  border-color: #f00;
}

```
### Output

``` css
input, select, textarea {
  border-color: #fff;
}
input:focus, select:focus, textarea:focus {
  border-color: #f00;
}

input,
select,
textarea {
  border-color: #fff;
}
input:focus,
select:focus,
textarea:focus {
  border-color: #f00;
}

input, select, textarea {
  border-color: #fff;
}
input:focus, select:focus, textarea:focus {
  border-color: #f00;
}

```
